### PR TITLE
Refactor model classes

### DIFF
--- a/src/main/java/linenux/command/DoneCommand.java
+++ b/src/main/java/linenux/command/DoneCommand.java
@@ -79,7 +79,7 @@ public class DoneCommand implements Command {
 
             if (1 <= index && index <= this.foundTasks.size()) {
                 Task task = this.foundTasks.get(index - 1);
-                task.markAsDone();
+                this.schedule.doneTask(task);
 
                 setResponse(false, null);
                 return makeDoneTask(task);

--- a/src/main/java/linenux/command/DoneCommand.java
+++ b/src/main/java/linenux/command/DoneCommand.java
@@ -53,7 +53,8 @@ public class DoneCommand implements Command {
 
         if (tasks.isLeft()) {
             if (tasks.getLeft().size() == 1) {
-                this.schedule.doneTask(tasks.getLeft().get(0));
+                Task task = tasks.getLeft().get(0);
+                this.schedule.updateTask(task, task.markAsDone());
                 return makeDoneTask(tasks.getLeft().get(0));
             } else {
                 setResponse(true, tasks.getLeft());
@@ -79,7 +80,7 @@ public class DoneCommand implements Command {
 
             if (1 <= index && index <= this.foundTasks.size()) {
                 Task task = this.foundTasks.get(index - 1);
-                this.schedule.doneTask(task);
+                this.schedule.updateTask(task, task.markAsDone());
 
                 setResponse(false, null);
                 return makeDoneTask(task);

--- a/src/main/java/linenux/command/EditCommand.java
+++ b/src/main/java/linenux/command/EditCommand.java
@@ -142,7 +142,7 @@ public class EditCommand implements Command {
         Either<Task, CommandResult> result = editArgumentParser.parse(original, argument);
 
         if (result.isLeft()) {
-            this.schedule.editTask(original, result.getLeft());
+            this.schedule.updateTask(original, result.getLeft());
             return makeEditedTask(original, result.getLeft());
         } else {
             return result.getRight();

--- a/src/main/java/linenux/command/RemindCommand.java
+++ b/src/main/java/linenux/command/RemindCommand.java
@@ -145,7 +145,7 @@ public class RemindCommand implements Command {
         Either<Reminder, CommandResult> result = reminderArgumentParser.parse(argument);
 
         if (result.isLeft()) {
-            this.schedule.addReminder(original, result.getLeft());
+            this.schedule.updateTask(original, original.addReminder(result.getLeft()));
             return makeResult(original, result.getLeft());
         } else {
             return result.getRight();

--- a/src/main/java/linenux/model/Reminder.java
+++ b/src/main/java/linenux/model/Reminder.java
@@ -16,6 +16,11 @@ public class Reminder {
         this.timeOfReminder = timeOfReminder;
     }
 
+    public Reminder(Reminder other) {
+        this.note = other.note;
+        this.timeOfReminder = other.timeOfReminder;
+    }
+
     /**
      * Creates a copy of the reminder.
      * @return

--- a/src/main/java/linenux/model/Reminder.java
+++ b/src/main/java/linenux/model/Reminder.java
@@ -21,14 +21,6 @@ public class Reminder {
         this.timeOfReminder = other.timeOfReminder;
     }
 
-    /**
-     * Creates a copy of the reminder.
-     * @return
-     */
-    public Reminder copyReminder() {
-        return new Reminder(this.getNote(), this.getTimeOfReminder());
-    }
-
     @Override
     public String toString() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd h:mma");
@@ -52,11 +44,15 @@ public class Reminder {
 
     /* Setters */
 
-    public void setNote(String newNote) {
-        this.note = newNote;
+    public Reminder setNote(String newNote) {
+        Reminder output = new Reminder(this);
+        output.note = newNote;
+        return output;
     }
 
-    public void setTimeOfReminder(LocalDateTime newTimeOfReminder) {
-        this.timeOfReminder = newTimeOfReminder;
+    public Reminder setTimeOfReminder(LocalDateTime newTimeOfReminder) {
+        Reminder output = new Reminder(this);
+        output.timeOfReminder = newTimeOfReminder;
+        return output;
     }
 }

--- a/src/main/java/linenux/model/Schedule.java
+++ b/src/main/java/linenux/model/Schedule.java
@@ -34,13 +34,12 @@ public class Schedule {
     }
 
     /**
-     * Edits the specified task.
-     *
-     * @param originalTask The original version of the specified task.
-     * @param newTask The edited version of the specified task.
+     * Replace {@code originalTask} with {@code newTask}.
+     * @param originalTask The original task.
+     * @param newTask The new ask.
      */
-    public void editTask(Task originalTask, Task newTask) {
-        addState(getMostRecentState().editTask(originalTask, newTask));
+    public void updateTask(Task originalTask, Task newTask) {
+        addState(getMostRecentState().updateTask(originalTask, newTask));
     }
 
     /**
@@ -50,22 +49,6 @@ public class Schedule {
      */
     public void deleteTask(Task task) {
         addState(getMostRecentState().deleteTask(task));
-    }
-
-    /**
-     * Marks specified task as done.
-     *
-     * @param task The task to mark as done.
-     */
-    public void doneTask(Task task) {
-        addState(getMostRecentState().doneTask(task));
-    }
-
-    /**
-     * Adds a reminder to a task.
-     */
-    public void addReminder(Task task, Reminder reminder) {
-        addState(getMostRecentState().addReminder(task, reminder));
     }
 
     /**

--- a/src/main/java/linenux/model/Schedule.java
+++ b/src/main/java/linenux/model/Schedule.java
@@ -16,14 +16,7 @@ public class Schedule {
      * Constructs an empty schedule
      */
     public Schedule() {
-        this(new ArrayList<>());
-    }
-
-    /**
-     * Constructs the schedule with the given data.
-     */
-    public Schedule(ArrayList<Task> taskList) {
-        this.states.add(new State(taskList));
+        this.states.add(new State());
     }
 
     /**

--- a/src/main/java/linenux/model/State.java
+++ b/src/main/java/linenux/model/State.java
@@ -63,7 +63,7 @@ import linenux.util.ArrayListUtil;
      public State doneTask(Task task) {
          int taskIndex = taskList.indexOf(task);
          ArrayList<Task> newTaskList = copyTaskList(taskList);
-         newTaskList.get(taskIndex).markAsDone();;
+         newTaskList.set(taskIndex, task.markAsDone());
          return new State(newTaskList);
      }
 
@@ -73,7 +73,7 @@ import linenux.util.ArrayListUtil;
      public State addReminder(Task task, Reminder reminder) {
          int taskIndex = taskList.indexOf(task);
          ArrayList<Task> newTaskList = copyTaskList(taskList);
-         newTaskList.get(taskIndex).addReminder(reminder);
+         newTaskList.set(taskIndex, task.addReminder(reminder));
          return new State(newTaskList);
      }
 
@@ -110,8 +110,8 @@ import linenux.util.ArrayListUtil;
       * @return
       */
      private ArrayList<Task> copyTaskList(ArrayList<Task> taskList) {
-         return new ArrayListUtil.ChainableArrayListUtil<Task>(taskList)
-                                 .map(task -> task.copyTask())
+         return new ArrayListUtil.ChainableArrayListUtil<>(taskList)
+                                 .map(Task::new)
                                  .value();
      }
 }

--- a/src/main/java/linenux/model/State.java
+++ b/src/main/java/linenux/model/State.java
@@ -15,8 +15,8 @@ import linenux.util.ArrayListUtil;
          this.taskList = new ArrayList<Task>();
      }
 
-     public State(ArrayList<Task> taskList) {
-         this.taskList = taskList;
+     public State(State other) {
+         this.taskList = new ArrayList<>(other.taskList);
      }
 
      /**
@@ -25,9 +25,9 @@ import linenux.util.ArrayListUtil;
       * @return The new State of the schedule.
       */
      public State addTask(Task task) {
-         ArrayList<Task> newTaskList = new ArrayList<>(taskList);
-         newTaskList.add(task);
-         return new State(newTaskList);
+         State output = new State(this);
+         output.taskList.add(task);
+         return output;
      }
 
      /**
@@ -38,9 +38,9 @@ import linenux.util.ArrayListUtil;
       */
      public State updateTask(Task originalTask, Task newTask) {
          int taskIndex = taskList.indexOf(originalTask);
-         ArrayList<Task> newTaskList = new ArrayList<>(taskList);
-         newTaskList.set(taskIndex, newTask);
-         return new State(newTaskList);
+         State output = new State(this);
+         output.taskList.set(taskIndex, newTask);
+         return output;
      }
 
      /**
@@ -50,9 +50,9 @@ import linenux.util.ArrayListUtil;
       */
      public State deleteTask(Task task) {
          int taskIndex = taskList.indexOf(task);
-         ArrayList<Task> newTaskList = new ArrayList<>(taskList);
-         newTaskList.remove(taskIndex);
-         return new State(newTaskList);
+         State output = new State(this);
+         output.taskList.remove(taskIndex);
+         return output;
      }
 
      /**

--- a/src/main/java/linenux/model/State.java
+++ b/src/main/java/linenux/model/State.java
@@ -25,7 +25,7 @@ import linenux.util.ArrayListUtil;
       * @return The new State of the schedule.
       */
      public State addTask(Task task) {
-         ArrayList<Task> newTaskList = copyTaskList(taskList);
+         ArrayList<Task> newTaskList = new ArrayList<>(taskList);
          newTaskList.add(task);
          return new State(newTaskList);
      }
@@ -38,7 +38,7 @@ import linenux.util.ArrayListUtil;
       */
      public State editTask(Task originalTask, Task newTask) {
          int taskIndex = taskList.indexOf(originalTask);
-         ArrayList<Task> newTaskList = copyTaskList(taskList);
+         ArrayList<Task> newTaskList = new ArrayList<>(taskList);
          newTaskList.set(taskIndex, newTask);
          return new State(newTaskList);
      }
@@ -50,7 +50,7 @@ import linenux.util.ArrayListUtil;
       */
      public State deleteTask(Task task) {
          int taskIndex = taskList.indexOf(task);
-         ArrayList<Task> newTaskList = copyTaskList(taskList);
+         ArrayList<Task> newTaskList = new ArrayList<>(taskList);
          newTaskList.remove(taskIndex);
          return new State(newTaskList);
      }
@@ -62,7 +62,7 @@ import linenux.util.ArrayListUtil;
       */
      public State doneTask(Task task) {
          int taskIndex = taskList.indexOf(task);
-         ArrayList<Task> newTaskList = copyTaskList(taskList);
+         ArrayList<Task> newTaskList = new ArrayList<>(taskList);
          newTaskList.set(taskIndex, task.markAsDone());
          return new State(newTaskList);
      }
@@ -72,7 +72,7 @@ import linenux.util.ArrayListUtil;
       */
      public State addReminder(Task task, Reminder reminder) {
          int taskIndex = taskList.indexOf(task);
-         ArrayList<Task> newTaskList = copyTaskList(taskList);
+         ArrayList<Task> newTaskList = new ArrayList<>(taskList);
          newTaskList.set(taskIndex, task.addReminder(reminder));
          return new State(newTaskList);
      }
@@ -101,17 +101,6 @@ import linenux.util.ArrayListUtil;
                                                                       .value();
                                                    return !Collections.disjoint(keywordsList, taskKeywords);
                                                    })
-                                 .value();
-     }
-
-     /**
-      * Creates a deep copy of the task list.
-      * @param taskList
-      * @return
-      */
-     private ArrayList<Task> copyTaskList(ArrayList<Task> taskList) {
-         return new ArrayListUtil.ChainableArrayListUtil<>(taskList)
-                                 .map(Task::new)
                                  .value();
      }
 }

--- a/src/main/java/linenux/model/State.java
+++ b/src/main/java/linenux/model/State.java
@@ -31,12 +31,12 @@ import linenux.util.ArrayListUtil;
      }
 
      /**
-      * Edits the specified task.
+      * Updates the specified task.
       *
       * @param originalTask The original version of the specified task.
       * @param newTask The edited version of the specified task.
       */
-     public State editTask(Task originalTask, Task newTask) {
+     public State updateTask(Task originalTask, Task newTask) {
          int taskIndex = taskList.indexOf(originalTask);
          ArrayList<Task> newTaskList = new ArrayList<>(taskList);
          newTaskList.set(taskIndex, newTask);
@@ -52,28 +52,6 @@ import linenux.util.ArrayListUtil;
          int taskIndex = taskList.indexOf(task);
          ArrayList<Task> newTaskList = new ArrayList<>(taskList);
          newTaskList.remove(taskIndex);
-         return new State(newTaskList);
-     }
-
-     /**
-      * Marks the specified task as done.
-      * @param task The task to mark as done.
-      * @return The new State of the schedule.
-      */
-     public State doneTask(Task task) {
-         int taskIndex = taskList.indexOf(task);
-         ArrayList<Task> newTaskList = new ArrayList<>(taskList);
-         newTaskList.set(taskIndex, task.markAsDone());
-         return new State(newTaskList);
-     }
-
-     /**
-      * Adds a reminder to a task.
-      */
-     public State addReminder(Task task, Reminder reminder) {
-         int taskIndex = taskList.indexOf(task);
-         ArrayList<Task> newTaskList = new ArrayList<>(taskList);
-         newTaskList.set(taskIndex, task.addReminder(reminder));
          return new State(newTaskList);
      }
 

--- a/src/main/java/linenux/model/Task.java
+++ b/src/main/java/linenux/model/Task.java
@@ -4,8 +4,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 
-import linenux.util.ArrayListUtil;
-
 /**
  * Represents a task in the schedule. Only taskName is a required field and
  * cannot be an empty string.
@@ -96,9 +94,7 @@ public class Task {
         this.startTime = other.startTime;
         this.endTime = other.endTime;
         this.tags = new ArrayList<>(other.tags);
-        this.reminders = new ArrayListUtil.ChainableArrayListUtil<>(other.reminders)
-                .map(Reminder::new)
-                .value();
+        this.reminders = new ArrayList<>(other.reminders);
     }
 
     @Override

--- a/src/main/java/linenux/model/Task.java
+++ b/src/main/java/linenux/model/Task.java
@@ -86,15 +86,19 @@ public class Task {
         this.reminders = new ArrayList<Reminder>();
     }
 
-    public Task copyTask() {
-        Task copyTask = new Task(taskName, startTime, endTime, tags);
-        copyTask.setIsDone(isDone);
-        copyTask.setCategories(
-                new ArrayListUtil.ChainableArrayListUtil<String>(tags)
-                        .map(tag -> tag.toString()).value());
-        copyTask.setReminders(new ArrayListUtil.ChainableArrayListUtil<Reminder>(reminders)
-                .map(reminder -> reminder.copyReminder()).value());
-        return copyTask;
+    /**
+     * Copy constructor.
+     * @param other The other {@code Task} to copy from.
+     */
+    public Task(Task other) {
+        this.taskName = other.taskName;
+        this.isDone = other.isDone;
+        this.startTime = other.startTime;
+        this.endTime = other.endTime;
+        this.tags = new ArrayList<>(other.tags);
+        this.reminders = new ArrayListUtil.ChainableArrayListUtil<>(other.reminders)
+                .map(Reminder::new)
+                .value();
     }
 
     @Override
@@ -155,36 +159,16 @@ public class Task {
 
     /* Setters */
 
-    public void setTaskName(String taskName) {
-        this.taskName = taskName;
+    public Task markAsDone() {
+        Task output = new Task(this);
+        output.isDone = true;
+        return output;
     }
 
-    public void markAsDone() {
-        this.isDone = true;
-    }
-
-    public void setIsDone(boolean isDone) {
-        this.isDone = isDone;
-    }
-
-    public void setStartTime(LocalDateTime startTime) {
-        this.startTime = startTime;
-    }
-
-    public void setEndTime(LocalDateTime endTime) {
-        this.endTime = endTime;
-    }
-
-    public void setCategories(ArrayList<String> tags) {
-        this.tags = tags;
-    }
-
-    public void addReminder(Reminder reminder) {
-        this.reminders.add(reminder);
-    }
-
-    public void setReminders(ArrayList<Reminder> reminders) {
-        this.reminders = reminders;
+    public Task addReminder(Reminder reminder) {
+        Task output = new Task(this);
+        output.reminders.add(reminder);
+        return output;
     }
 
     private String tagsToString() {

--- a/src/test/java/linenux/command/RemindCommandTest.java
+++ b/src/test/java/linenux/command/RemindCommandTest.java
@@ -26,16 +26,14 @@ public class RemindCommandTest {
 
     @Before
     public void setupRemindCommand() {
-        ArrayList<Task> tasks = new ArrayList<>();
         Task todo = new Task("Todo");
         Task deadline = new Task("Deadline", LocalDateTime.of(2016, 1, 1, 1, 0));
         Task event = new Task("Event", LocalDateTime.of(2016, 1, 1, 1, 0), LocalDateTime.of(2016, 1, 1, 13, 0));
 
-        tasks.add(todo);
-        tasks.add(deadline);
-        tasks.add(event);
-
-        this.schedule = new Schedule(tasks);
+        this.schedule = new Schedule();
+        this.schedule.addTask(todo);
+        this.schedule.addTask(deadline);
+        this.schedule.addTask(event);
         this.remindCommand = new RemindCommand(this.schedule);
     }
 


### PR DESCRIPTION
Made some changes to the model classes:

1. Since all our model classes are immutable, they should not have (public) mutable methods. I've updated all the mutation methods to return a new instance instead of mutating the properties in-place. For example, take a look at [`Task#markAsDone`](https://github.com/CS2103AUG2016-W11-C1/main/blob/d7425bce02f458b85412061d8b39e43c1d88253f/src/main/java/linenux/model/Task.java#L158-L162).

2. Initially I said that we need to make deep copies of everything. I notice that this is actually not true. Since all model objects are immutable, there is no difference between a deep or shallow copy.

3. Instead of implementing `copy*` method (for e.g., the [`Task#copyTask`](https://github.com/CS2103AUG2016-W11-C1/main/blob/d7425bce02f458b85412061d8b39e43c1d88253f/src/main/java/linenux/model/Task.java#L87-L98) method), I'm using copy constructors instead (for e.g., in [`Task`](https://github.com/CS2103AUG2016-W11-C1/main/blob/d7425bce02f458b85412061d8b39e43c1d88253f/src/main/java/linenux/model/Task.java#L87-L98)), which I think is more idiomatic.

4. Instead of exposing several variations of task mutation methods (for e.g., [`Schedule#doneTask`](https://github.com/CS2103AUG2016-W11-C1/main/blob/2fe880fae625639c8421f7ab6db826bd88d0d84b/src/main/java/linenux/model/Schedule.java#L55-L62) and [`Schedule#addReminder`](https://github.com/CS2103AUG2016-W11-C1/main/blob/2fe880fae625639c8421f7ab6db826bd88d0d84b/src/main/java/linenux/model/Schedule.java#L64-L69)) on the `Schedule` and `State` tasks, I'm exposing exactly three mutation methods: [`addTask`](https://github.com/CS2103AUG2016-W11-C1/main/blob/d7425bce02f458b85412061d8b39e43c1d88253f/src/main/java/linenux/model/Schedule.java#L22-L27), [`updateTask`](https://github.com/CS2103AUG2016-W11-C1/main/blob/d7425bce02f458b85412061d8b39e43c1d88253f/src/main/java/linenux/model/Schedule.java#L29-L36), and [`deleteTask`](https://github.com/CS2103AUG2016-W11-C1/main/blob/d7425bce02f458b85412061d8b39e43c1d88253f/src/main/java/linenux/model/Schedule.java#L38-L45). Most of the previous mutation methods can be achieved using the `updateTask` method. For example, instead of calling `schedule.doneTask(task)`, now we call `schedule.updateTask(task, task.markAsDone())`. The benefit of doing this is twofold:

    - The previous way of doing things is unscalable and repetitive. The reason is that for every possible mutation that we want to perform on the task object, we need to implement the corresponding method for `Schedule` and `State`.
    - The previous API can become complicated and inscrutable very quickly. For example, when we implement the edit reminder command, we will need something like `schedule.editReminder(task, oldReminder, newReminder)`. Instead, I think it is clearer to do `schedule.updateTask(task, task.updateReminder(oldReminder, newReminder))`.

tl;dr

- Model objects should be immutable. All mutations should return a new instance and leaving the old one untouched.
- We now have a standardized API for `Schedule` to perform mutation, which is the `updateTask` method. `updateTask` should be sufficient for all mutations, hence, do not implement other mutation methods on `Schedule` unless absolutely necessary.

/cc @cadmusthefounder @Kaiiiii @Roahhh 