### PR TITLE
Refactor all the parsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
 jdk:
   - oraclejdk8
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 script:
   - "./gradlew build"
   - "./gradlew test"

--- a/src/main/java/linenux/command/parser/GenericParser.java
+++ b/src/main/java/linenux/command/parser/GenericParser.java
@@ -1,0 +1,92 @@
+package linenux.command.parser;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Created by yihangho on 10/22/16.
+ */
+public class GenericParser {
+    private static final Pattern FIRST_FLAG_PATTERN = Pattern.compile("(^|\\s+)\\S+/");
+    private static final Pattern FLAG_PATTERN = Pattern.compile("\\S+/");
+    private static final Pattern NEXT_FLAG_PATTERN = Pattern.compile("\\s+\\S+/");
+
+    public GenericParserResult parse(String input) {
+        GenericParserResult output = new GenericParserResult();
+
+        String keywords = this.extractKeywords(input);
+        output.setKeywords(keywords.trim());
+
+        this.extractFlags(input, keywords.length(), output);
+
+        return output;
+    }
+
+    private String extractKeywords(String input) {
+        Matcher matcher = FIRST_FLAG_PATTERN.matcher(input);
+
+        // Find the first flag. If there is no flag, the end index is at the end of string.
+        int earliestIndex = input.length();
+        if (matcher.find()) {
+            earliestIndex = matcher.start();
+        }
+
+        return input.substring(0, earliestIndex);
+    }
+
+    private void extractFlags(String input, int index, GenericParserResult result) {
+        for (int i = index; i < input.length(); ) {
+            // Find where the next flag starts. This is necessary as i might be pointing to a
+            // space.
+            int startingIndex = input.length();
+            Matcher matcher = FLAG_PATTERN.matcher(input);
+            if (matcher.find(i)) {
+                startingIndex = matcher.start();
+            }
+
+            if (startingIndex >= input.length()) {
+                return;
+            }
+
+            int endingIndex = input.length();
+            matcher = NEXT_FLAG_PATTERN.matcher(input);
+            if (matcher.find(startingIndex + 1)) {
+                endingIndex = matcher.start();
+            }
+
+            String chunk = input.substring(startingIndex, endingIndex);
+            String[] chunks = chunk.split("/", 2);
+            result.addArgument(chunks[0], chunks[1].trim());
+
+            i = endingIndex + 1;
+        }
+    }
+
+    public static class GenericParserResult {
+        // Perhaps we can use Optionals to signal the presence of these values.
+        private String keywords;
+        private HashMap<String, ArrayList<String>> arguments = new HashMap<>();
+
+        public String getKeywords() {
+            return this.keywords;
+        }
+
+        public void setKeywords(String keywords) {
+            this.keywords = keywords;
+        }
+
+        public ArrayList<String> getArguments(String flag) {
+            return this.arguments.getOrDefault(flag, new ArrayList<>());
+        }
+
+        public void addArgument(String flag, String value) {
+            if (!this.arguments.containsKey(flag)) {
+                this.arguments.put(flag, new ArrayList<>());
+            }
+
+            this.arguments.get(flag).add(value);
+        }
+    }
+}

--- a/src/main/java/linenux/model/Reminder.java
+++ b/src/main/java/linenux/model/Reminder.java
@@ -11,6 +11,10 @@ public class Reminder {
     private String note;
     private LocalDateTime timeOfReminder;
 
+    public Reminder() {
+        this(null, null);
+    }
+
     public Reminder(String note, LocalDateTime timeOfReminder) {
         this.note = note;
         this.timeOfReminder = timeOfReminder;

--- a/src/main/java/linenux/model/Task.java
+++ b/src/main/java/linenux/model/Task.java
@@ -159,6 +159,24 @@ public class Task {
 
     /* Setters */
 
+    public Task setTaskName(String taskName) {
+        Task output = new Task(this);
+        output.taskName = taskName;
+        return output;
+    }
+
+    public Task setStartTime(LocalDateTime startTime) {
+        Task output = new Task(this);
+        output.startTime = startTime;
+        return output;
+    }
+
+    public Task setEndTime(LocalDateTime endTime) {
+        Task output = new Task(this);
+        output.endTime = endTime;
+        return output;
+    }
+
     public Task markAsDone() {
         Task output = new Task(this);
         output.isDone = true;
@@ -168,6 +186,12 @@ public class Task {
     public Task addReminder(Reminder reminder) {
         Task output = new Task(this);
         output.reminders.add(reminder);
+        return output;
+    }
+
+    public Task setTags(ArrayList<String> tags) {
+        Task output = new Task(this);
+        output.tags = tags;
         return output;
     }
 

--- a/src/main/java/linenux/util/ArrayListUtil.java
+++ b/src/main/java/linenux/util/ArrayListUtil.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -188,6 +189,26 @@ public class ArrayListUtil {
             xs.add(x);
             return xs;
         }, new ArrayList<T>(), list);
+    }
+
+    /**
+     * Returns a new list by removing repeated elements in {@code list}.
+     * @param list The input list.
+     * @param <T> The type of the list.
+     * @return The list with repeated elements removed.
+     */
+    public static <T> ArrayList<T> unique(ArrayList<T> list) {
+        HashSet<T> set = new HashSet<>();
+        ArrayList<T> output = new ArrayList<>();
+
+        for (T val: list) {
+            if (!set.contains(val)) {
+                set.add(val);
+                output.add(val);
+            }
+        }
+
+        return output;
     }
 
     /**

--- a/src/main/java/linenux/util/Either.java
+++ b/src/main/java/linenux/util/Either.java
@@ -1,6 +1,7 @@
 package linenux.util;
 
 import java.util.NoSuchElementException;
+import java.util.function.Function;
 
 /**
  * A data structure inspired by the FP world. Can be used to represent an operation that can have two possible
@@ -111,5 +112,19 @@ public class Either<L, R> {
      */
     public R getRight() {
         return this.right.get();
+    }
+
+    /**
+     * Execute a function with the left value skip otherwise.
+     * @param function The function to execute.
+     * @param <T> The normal return type of {@code function}.
+     * @return An {@code Either}.
+     */
+    public <T> Either<T, R> bind(Function<L, Either<T, R>> function) {
+        if (this.isRight()) {
+            return Either.right(this.getRight());
+        } else {
+            return function.apply(this.getLeft());
+        }
     }
 }

--- a/src/main/java/linenux/util/TimeInterval.java
+++ b/src/main/java/linenux/util/TimeInterval.java
@@ -8,6 +8,14 @@ import java.time.LocalDateTime;
 public class TimeInterval {
     private LocalDateTime from, to;
 
+    public TimeInterval() {
+        this(null, null);
+    }
+
+    public TimeInterval(TimeInterval other) {
+        this(other.from, other.to);
+    }
+
     public TimeInterval(LocalDateTime from, LocalDateTime to) {
         this.from = from;
         this.to = to;
@@ -19,6 +27,14 @@ public class TimeInterval {
 
     public LocalDateTime getTo() {
         return this.to;
+    }
+
+    public TimeInterval setFrom(LocalDateTime from) {
+        return new TimeInterval(from, this.to);
+    }
+
+    public TimeInterval setTo(LocalDateTime to) {
+        return new TimeInterval(this.from, to);
     }
 
     /**

--- a/src/test/java/linenux/command/parser/GenericParserTest.java
+++ b/src/test/java/linenux/command/parser/GenericParserTest.java
@@ -1,0 +1,140 @@
+package linenux.command.parser;
+
+import linenux.util.ArrayListUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static junit.framework.TestCase.assertEquals;
+
+/**
+ * Created by yihangho on 10/22/16.
+ */
+public class GenericParserTest {
+    private GenericParser parser;
+
+    @Before
+    public void setupParser() {
+        this.parser = new GenericParser();
+    }
+
+    @Test
+    public void testKeywordsWithoutFlags() {
+        GenericParser.GenericParserResult result = parser.parse("hello world");
+        assertEquals("hello world", result.getKeywords());
+    }
+
+    @Test
+    public void testTrimKeywordsWithoutFlags() {
+        GenericParser.GenericParserResult result = parser.parse("   hello world    ");
+        assertEquals("hello world", result.getKeywords());
+    }
+
+    @Test
+    public void testKeywordsWithFlags() {
+        GenericParser.GenericParserResult result = parser.parse("hello world st/12345");
+        assertEquals("hello world", result.getKeywords());
+    }
+
+    @Test
+    public void testTrimKeywordsWithFlags() {
+        GenericParser.GenericParserResult result = parser.parse("  hello world      st/12345");
+        assertEquals("hello world", result.getKeywords());
+    }
+
+    @Test
+    public void testExtractFlags() {
+        GenericParser.GenericParserResult result = parser.parse("hello world st/12345");
+        ArrayList<String> flagValues = result.getArguments("st");
+        assertEquals(1, flagValues.size());
+        assertEquals("12345", flagValues.get(0));
+    }
+
+    @Test
+    public void testExtractRepeatedFlags() {
+        GenericParser.GenericParserResult result = parser.parse("hello world st/12345 st/67890");
+        ArrayList<String> flagValues = result.getArguments("st");
+        assertEquals(2, flagValues.size());
+        assertEquals("12345", flagValues.get(0));
+        assertEquals("67890", flagValues.get(1));
+    }
+
+    @Test
+    public void testRepeatedButSeparatedFlags() {
+        GenericParser.GenericParserResult result = parser.parse("hello world st/1 et/2 st/3");
+        ArrayList<String> flagValues = result.getArguments("st");
+        assertEquals(2, flagValues.size());
+        assertEquals("1", flagValues.get(0));
+        assertEquals("3", flagValues.get(1));
+        flagValues = result.getArguments("et");
+        assertEquals(1, flagValues.size());
+        assertEquals("2", flagValues.get(0));
+    }
+
+    @Test
+    public void testNonWordFlags() {
+        GenericParser.GenericParserResult result = parser.parse("hello world #/yo #/foo");
+        ArrayList<String> flagValues = result.getArguments("#");
+        assertEquals(2, flagValues.size());
+        assertEquals("yo", flagValues.get(0));
+        assertEquals("foo", flagValues.get(1));
+    }
+
+    @Test
+    public void testMultiwordsFlags() {
+        GenericParser.GenericParserResult result = parser.parse("hello world st/Jan 1 et/Jan 2");
+        ArrayList<String> flagValues = result.getArguments("st");
+        assertEquals(1, flagValues.size());
+        assertEquals("Jan 1", flagValues.get(0));
+        flagValues = result.getArguments("et");
+        assertEquals(1, flagValues.size());
+        assertEquals("Jan 2", flagValues.get(0));
+    }
+
+    @Test
+    public void testEmptyFlags() {
+        GenericParser.GenericParserResult result = parser.parse("hello st/");
+        assertEquals("hello", result.getKeywords());
+        ArrayList<String> flagValues = result.getArguments("st");
+        assertEquals(1, flagValues.size());
+        assertEquals("", flagValues.get(0));
+    }
+
+    @Test
+    public void testEmptyFlagFollowBySomething() {
+        GenericParser.GenericParserResult result = parser.parse("hello st/  et/12345");
+        assertEquals("hello", result.getKeywords());
+        ArrayList<String> flagValues = result.getArguments("st");
+        assertEquals(1, flagValues.size());
+        assertEquals("", flagValues.get(0));
+        flagValues = result.getArguments("et");
+        assertEquals(1, flagValues.size());
+        assertEquals("12345", flagValues.get(0));
+    }
+
+    @Test
+    public void testFlagValueContainsSlash() {
+        GenericParser.GenericParserResult result = parser.parse("hello st/2016/01/01");
+        ArrayList<String> flagValues = result.getArguments("st");
+        assertEquals(1, flagValues.size());
+        assertEquals("2016/01/01", flagValues.get(0));
+    }
+
+    @Test
+    public void testLastFlagValueWithTrailingSpaces() {
+        GenericParser.GenericParserResult result = parser.parse("hello st/12345       ");
+        ArrayList<String> flagValue = result.getArguments("st");
+        assertEquals(1, flagValue.size());
+        assertEquals("12345", flagValue.get(0));
+    }
+
+    @Test
+    public void testEmptyKeywords() {
+        GenericParser.GenericParserResult result = parser.parse("st/12345");
+        assertEquals("", result.getKeywords());
+        ArrayList<String> flagValues = result.getArguments("st");
+        assertEquals(1, flagValues.size());
+        assertEquals("12345", flagValues.get(0));
+    }
+}

--- a/src/test/java/linenux/util/ArrayListUtilTest.java
+++ b/src/test/java/linenux/util/ArrayListUtilTest.java
@@ -55,6 +55,13 @@ public class ArrayListUtilTest {
         assertEquals("1", strings.get(2));
     }
 
+    @Test
+    public void testUnique() {
+        ArrayList<Integer> numbers = ArrayListUtil.fromArray(new Integer[]{1, 2, 2, 1, 3, 1, 3, 2});
+        ArrayList<Integer> uniqueNumbers = ArrayListUtil.unique(numbers);
+        assertEquals(3, uniqueNumbers.size());
+    }
+
     public void testFromSingleton() {
         ArrayList<String> strings = ArrayListUtil.fromSingleton("hello");
         assertEquals(1, strings.size());

--- a/src/test/java/linenux/util/EitherTest.java
+++ b/src/test/java/linenux/util/EitherTest.java
@@ -3,6 +3,7 @@ package linenux.util;
 import org.junit.Test;
 
 import java.util.NoSuchElementException;
+import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -36,5 +37,48 @@ public class EitherTest {
     @Test(expected=NoSuchElementException.class)
     public void testGetRightShouldThrow() {
         Either.left("hello").getRight();
+    }
+
+    @Test
+    public void testIsLeftBindReturnsLeft() {
+        Either<Integer, Integer> either = Either.left(1);
+        Either<Integer, Integer> result = either.bind(i -> Either.left(i + 1));
+
+        assertTrue(result.isLeft());
+        assertEquals(2, (int)result.getLeft());
+    }
+
+    @Test
+    public void testIsLeftBindReturnsRight() {
+        Either<Integer, Integer> either = Either.left(1);
+        Either<Integer, Integer> result = either.bind(i -> Either.right(i + 1));
+
+        assertTrue(result.isRight());
+        assertEquals(2, (int)result.getRight());
+    }
+
+    private class MockLambda implements Function<Integer, Either<Integer, Integer>> {
+        private boolean executed = false;
+
+        @Override
+        public Either<Integer, Integer> apply(Integer integer) {
+            this.executed = true;
+            return Either.left(integer + 1);
+        }
+
+        public boolean isExecuted() {
+            return this.executed;
+        }
+    }
+
+    @Test
+    public void testIsRightBind() {
+        MockLambda fn = new MockLambda();
+        Either<Integer, Integer> either = Either.right(1);
+        Either<Integer, Integer> result = either.bind(fn);
+
+        assertFalse(fn.isExecuted());
+        assertTrue(result.isRight());
+        assertEquals(1, (int)result.getRight());
     }
 }


### PR DESCRIPTION
1. Implement [`GenericParser`](https://github.com/CS2103AUG2016-W11-C1/main/blob/e84550802c345ca721c656fcea5c8c412afe885f/src/main/java/linenux/command/parser/GenericParser.java). `GenericParser` is a low level parser that takes in everything after a command and returns the keywords and the values of each argument. For example,

    ```java
    GenericParserResult result = new GenericParser.parse("hello world st/Jan 1 et/Jan 2 #/tag1 #/tag2");
    result.getKeywords() == "hello world";
    result.getArguments("st") == ["Jan 1"];
    result.getArguments("et") == ["Jan 2"];
    result.getArguments("#") == ["tag1", "tag2"];
    ```

    Whoever reviewing this PR please take a closer look at the [tests](https://github.com/CS2103AUG2016-W11-C1/main/blob/e84550802c345ca721c656fcea5c8c412afe885f/src/test/java/linenux/command/parser/GenericParserTest.java) and suggest if I've missed out any cases. This is important as the correctness of other parsers depend on the correctness of `GenericParser`.

2. Implement [`Either#bind`](https://github.com/CS2103AUG2016-W11-C1/main/blob/e84550802c345ca721c656fcea5c8c412afe885f/src/main/java/linenux/util/Either.java#L117-L129). By convention, we use a right either to represent failures. `Either#bind` takes in a function that returns an `Either`. The function is executed if the current `Either` is not a failure. For example,

    ```java
    return either.bind(fn);

    // is the same as

    if (either.isLeft()) {
        return fn.apply(either.getLeft());
    } else {
        return Either.right(either.getRight());
    }
    ```

3. Actually refactoring the parsers.