### PR TITLE
Fix location of done tasks

### DIFF
--- a/src/main/java/linenux/command/filter/ListArgumentFilter.java
+++ b/src/main/java/linenux/command/filter/ListArgumentFilter.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.function.Predicate;
 
 import linenux.command.result.CommandResult;
 import linenux.control.TimeParserManager;
@@ -150,6 +151,14 @@ public class ListArgumentFilter {
         }
 
         return Either.left(filteredReminders);
+    }
+
+    public ArrayList<Task> filterUndoneTasks(ArrayList<Task> tasks) {
+        ArrayList<Task> undoneTasks = new ArrayListUtil.ChainableArrayListUtil<>(tasks)
+                .filter(((Predicate<Task>) Task::isDone).negate())
+                .value();
+
+        return undoneTasks;
     }
 
     private Either<LocalDateTime, CommandResult> extractStartTime(String argument) {

--- a/src/main/java/linenux/command/filter/ListArgumentFilter.java
+++ b/src/main/java/linenux/command/filter/ListArgumentFilter.java
@@ -155,7 +155,7 @@ public class ListArgumentFilter {
 
     public ArrayList<Task> filterUndoneTasks(ArrayList<Task> tasks) {
         ArrayList<Task> undoneTasks = new ArrayListUtil.ChainableArrayListUtil<>(tasks)
-                .filter(((Predicate<Task>) Task::isDone).negate())
+                .filter(Task::isNotDone)
                 .value();
 
         return undoneTasks;

--- a/src/main/java/linenux/view/DeadlineBoxController.java
+++ b/src/main/java/linenux/view/DeadlineBoxController.java
@@ -41,7 +41,10 @@ public class DeadlineBoxController {
 
     private void updateDeadlines() {
         ArrayList<Task> tasks = this.controlUnit.getSchedule().getTaskList();
-        ArrayList<Task> deadlines = filterDeadlines(tasks);
+        ArrayList<Task> undoneTasks = new ArrayListUtil.ChainableArrayListUtil<>(tasks)
+                .filter(((Predicate<Task>) Task::isDone).negate())
+                .value();
+        ArrayList<Task> deadlines = filterDeadlines(undoneTasks);
         this.deadlines.setAll(deadlines);
     }
 
@@ -54,7 +57,6 @@ public class DeadlineBoxController {
     private ArrayList<Task> filterDeadlines(ArrayList<Task> tasks) {
         ArrayList<Task> deadlines = new ArrayListUtil.ChainableArrayListUtil<>(tasks)
                 .filter(Task::isDeadline)
-                .filter(((Predicate<Task>) Task::isDone).negate())
                 .sortBy(Task::getTaskName)
                 .sortBy(Task::getEndTime)
                 .value();

--- a/src/main/java/linenux/view/DeadlineBoxController.java
+++ b/src/main/java/linenux/view/DeadlineBoxController.java
@@ -42,7 +42,7 @@ public class DeadlineBoxController {
     private void updateDeadlines() {
         ArrayList<Task> tasks = this.controlUnit.getSchedule().getTaskList();
         ArrayList<Task> undoneTasks = new ArrayListUtil.ChainableArrayListUtil<>(tasks)
-                .filter(((Predicate<Task>) Task::isDone).negate())
+                .filter(Task::isNotDone)
                 .value();
         ArrayList<Task> deadlines = filterDeadlines(undoneTasks);
         this.deadlines.setAll(deadlines);

--- a/src/main/java/linenux/view/EventBoxController.java
+++ b/src/main/java/linenux/view/EventBoxController.java
@@ -41,7 +41,10 @@ public class EventBoxController {
 
     private void updateEvents() {
         ArrayList<Task> tasks = this.controlUnit.getSchedule().getTaskList();
-        ArrayList<Task> events = filterEvents(tasks);
+        ArrayList<Task> undoneTasks = new ArrayListUtil.ChainableArrayListUtil<>(tasks)
+                .filter(((Predicate<Task>) Task::isDone).negate())
+                .value();
+        ArrayList<Task> events = filterEvents(undoneTasks);
         this.events.setAll(events);
     }
 
@@ -54,7 +57,6 @@ public class EventBoxController {
     private ArrayList<Task> filterEvents(ArrayList<Task> tasks) {
         ArrayList<Task> events = new ArrayListUtil.ChainableArrayListUtil<>(tasks)
                 .filter(Task::isEvent)
-                .filter(((Predicate<Task>) Task::isDone).negate())
                 .sortBy(Task::getTaskName)
                 .sortBy(Task::getStartTime)
                 .value();

--- a/src/main/java/linenux/view/EventBoxController.java
+++ b/src/main/java/linenux/view/EventBoxController.java
@@ -42,7 +42,7 @@ public class EventBoxController {
     private void updateEvents() {
         ArrayList<Task> tasks = this.controlUnit.getSchedule().getTaskList();
         ArrayList<Task> undoneTasks = new ArrayListUtil.ChainableArrayListUtil<>(tasks)
-                .filter(((Predicate<Task>) Task::isDone).negate())
+                .filter(Task::isNotDone)
                 .value();
         ArrayList<Task> events = filterEvents(undoneTasks);
         this.events.setAll(events);

--- a/src/main/java/linenux/view/TodoBoxController.java
+++ b/src/main/java/linenux/view/TodoBoxController.java
@@ -41,7 +41,10 @@ public class TodoBoxController {
 
     private void updateTodos() {
         ArrayList<Task> tasks = this.controlUnit.getSchedule().getTaskList();
-        ArrayList<Task> todos = filterToDos(tasks);
+        ArrayList<Task> undoneTasks = new ArrayListUtil.ChainableArrayListUtil<>(tasks)
+                .filter(((Predicate<Task>) Task::isDone).negate())
+                .value();
+        ArrayList<Task> todos = filterToDos(undoneTasks);
         this.todos.setAll(todos);
     }
 


### PR DESCRIPTION
When calling d/all and d/yes, done tasks will no longer show up in the results panel, but will show in their respective panels. Main changes to view:

1. It used to filter out done tasks while we filter for each panel's task(i.e filtering for events etc). I shifted that out to make that occur only when we make changes to Schedule. Thus, adding any ArrayList of Tasks to filteredTaskList in Schedule will display all tasks in the newly added ArrayList of tasks without filtering out done task.

Also, made it such that when call d/yes (view only done tasks), to show only done tasks, and leave out all the reminders, main reason is because reminders doesn't have the notion of done.

